### PR TITLE
Fxed event emit outputting default value

### DIFF
--- a/src/time-control/mat-timepicker-toggle/mat-timepicker-toggle.component.ts
+++ b/src/time-control/mat-timepicker-toggle/mat-timepicker-toggle.component.ts
@@ -111,6 +111,6 @@ export class MatTimepickerToggleComponent implements OnInit {
 
   private emituserTimeChange() {
 
-    this.userTimeChange.emit(this.userTime);
+    this.userTimeChange.emit(this.timepicker.userTime);
   }
 }


### PR DESCRIPTION
this.usertime is never updated but this.timepicker.userTime is so I just switched it to that.